### PR TITLE
Compile with Qt5 and OpenCV 3.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ if(NOT DEFINED OpenCV_PREFIX)
 endif()
 
 # Configurable options
-OPTION(WITH_GUI "Build the GUI" ON)
+OPTION(WITH_GUI "Build the GUI" OFF)
 
 # # Third party libraries
 # find_package(OpenCV REQUIRED core highgui imgproc objdetect
@@ -20,15 +20,10 @@ OPTION(WITH_GUI "Build the GUI" ON)
 #   NO_DEFAULT_PATH) # For some reason CMake uses its defaults before the above paths.
 
 # opencv
-if(WIN32)
-    set(opencv_DIR E:/toolkits/opencv-3.2.0-contrib-cpu)
-endif(WIN32)
-if(APPLE)
-    set(opencv_DIR ~/toolkits/opencv-3.4.1-mac/share/OpenCV)
-endif(APPLE)
-find_package(opencv REQUIRED)
+set(OpenCV_DIR "" CACHE PATH "OpenCV root directory")
+find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
-message("OpenCV_INCLUDE_DIRS = ${OpenCV_INCLUDE_DIRS}")
+# message("OpenCV_INCLUDE_DIRS = ${OpenCV_INCLUDE_DIRS}")
 
 IF(APPLE)
 find_library(FOUNDATION Foundation)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # -*-cmake-*-
 PROJECT(CSIRO-FaceAnalysis-SDK)
 
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1.0)
 
 #set(CMAKE_VERBOSE_MAKEFILE true)
 
@@ -11,13 +11,24 @@ if(NOT DEFINED OpenCV_PREFIX)
 endif()
 
 # Configurable options
-OPTION(WITH_GUI "Build the GUI" OFF)
+OPTION(WITH_GUI "Build the GUI" ON)
 
-# Third party libraries
-find_package(OpenCV REQUIRED core highgui imgproc objdetect
-  PATHS ${OpenCV_PREFIX}/lib/cmake/
-        ${OpenCV_PREFIX}/share/OpenCV/
-  NO_DEFAULT_PATH) # For some reason CMake uses its defaults before the above paths.
+# # Third party libraries
+# find_package(OpenCV REQUIRED core highgui imgproc objdetect
+#   PATHS ${OpenCV_PREFIX}/lib/cmake/
+#         ${OpenCV_PREFIX}/share/OpenCV/
+#   NO_DEFAULT_PATH) # For some reason CMake uses its defaults before the above paths.
+
+# opencv
+if(WIN32)
+    set(opencv_DIR E:/toolkits/opencv-3.2.0-contrib-cpu)
+endif(WIN32)
+if(APPLE)
+    set(opencv_DIR ~/toolkits/opencv-3.4.1-mac/share/OpenCV)
+endif(APPLE)
+find_package(opencv REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+message("OpenCV_INCLUDE_DIRS = ${OpenCV_INCLUDE_DIRS}")
 
 IF(APPLE)
 find_library(FOUNDATION Foundation)

--- a/src/display-tracking/main.cpp
+++ b/src/display-tracking/main.cpp
@@ -21,7 +21,7 @@
 #include "utils/command-line-arguments.hpp"
 #include "utils/points.hpp"
 #include <iostream>
-#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/opencv.hpp>
 
 void
 print_usage()

--- a/src/expression-transfer/main.cpp
+++ b/src/expression-transfer/main.cpp
@@ -209,7 +209,7 @@ run_program(int argc, char **argv)
   
     if (image_exists_p && landmarks_exists_p) {
       cv::Mat image_unknown = cv::imread(image_it->c_str());
-      if (image_unknown.type() != cv::DataType<cv::Vec<uint8_t,3> >::type)	
+      if (image_unknown.type() != CV_8UC3)	
 	throw make_runtime_error("This program only knows draw on 3 channel colour images. The file '%s' just doesn't satisfy this requirement. Sorry.", image_it->c_str());
 
       cv::Mat_<cv::Vec<uint8_t,3> > image  = image_unknown;

--- a/src/face-fit/main.cpp
+++ b/src/face-fit/main.cpp
@@ -296,7 +296,7 @@ run_video_mode(const Configuration &cfg,
     }
 
     cv::Mat_<uint8_t> gray_image;
-    if (image.type() == cv::DataType<cv::Vec<uint8_t,3> >::type)
+    if (image.type() == CV_8UC3)
       cv::cvtColor(image, gray_image, CV_BGR2GRAY);
     else if (image.type() == cv::DataType<uint8_t>::type)
       gray_image = image;
@@ -414,13 +414,13 @@ display_data(const Configuration &cfg,
   cv::Scalar colour;
   if (image.type() == cv::DataType<uint8_t>::type)
     colour = cv::Scalar(255);
-  else if (image.type() == cv::DataType<cv::Vec<uint8_t,3> >::type)
+  else if (image.type() == CV_8UC3)
     colour = cv::Scalar(0,0,255);
   else
     colour = cv::Scalar(255);
 
   cv::Mat displayed_image;
-  if (image.type() == cv::DataType<cv::Vec<uint8_t,3> >::type)
+  if (image.type() == CV_8UC3)
     displayed_image = image.clone();
   else if (image.type() == cv::DataType<uint8_t>::type)
     cv::cvtColor(image, displayed_image, CV_GRAY2BGR);

--- a/src/qt-gui/CMakeLists.txt
+++ b/src/qt-gui/CMakeLists.txt
@@ -1,39 +1,93 @@
 # -*-cmake-*-
-find_package(Qt4 REQUIRED)
+# find_package(Qt4 REQUIRED)
 
-INCLUDE( ${QT_USE_FILE} )
+# INCLUDE( ${QT_USE_FILE} )
+
+# qt
+if(APPLE)
+    set(QTDIR /Users/lusheng/Qt/5.11.1/clang_64)
+    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QTDIR})
+endif(APPLE)
+find_package(Qt5Widgets CONFIG REQUIRED)
+include_directories(${Qt5Widgets_INCLUDE_DIRS})
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+# opencv
+if(WIN32)
+    set(opencv_DIR E:/toolkits/opencv-3.2.0-contrib-cpu)
+endif(WIN32)
+if(APPLE)
+    set(opencv_DIR ~/toolkits/opencv-3.4.1-mac/share/OpenCV)
+endif(APPLE)
+find_package(opencv REQUIRED)
+include_directories(${OpenCV_INCLUDE_DIRS})
+message("OpenCV_INCLUDE_DIRS = ${OpenCV_INCLUDE_DIRS}")
 
 #set(CMAKE_VERBOSE_MAKEFILE true)
 
 SET(BundleName "qt-gui")
 
-SET(guiFILES "application-states.cpp"
-  "controllers.cpp"
-  "configuration.cpp"
-  "gui/avatar-selection.cpp"
-  "gui/main-window.cpp"
-  "gui/avatar.cpp"
-  "gui/mesh-drawer.cpp"
-  "gui/graphics-scrollbar.cpp"
-  "gui/windowed-gui-controller.cpp"
-  "gui/item-controllers.cpp"
-  "gui/worker-thread.cpp"
-  "gui/item-positions-calculator.cpp"
+SET(guiFILES 
+  # "application-states.cpp"
+  # "controllers.cpp"
+  # "configuration.cpp"
+  # "gui/avatar-selection.cpp"
+  # "gui/main-window.cpp"
+  # "gui/avatar.cpp"
+  # "gui/mesh-drawer.cpp"
+  # "gui/graphics-scrollbar.cpp"
+  # "gui/windowed-gui-controller.cpp"
+  # "gui/item-controllers.cpp"
+  # "gui/worker-thread.cpp"
+  # "gui/item-positions-calculator.cpp"
+
+  application-states.cpp
+  controllers.cpp
+  configuration.cpp
+  gui/main-window.cpp
+  gui/windowed-gui-controller.cpp
+  gui/item-controllers.cpp
+  gui/item-positions-calculator.cpp
+  gui/graphics-scrollbar.cpp
+  gui/avatar-selection.cpp
+  gui/avatar.cpp
+  gui/worker-thread.cpp
+  gui/mesh-drawer.cpp
+
+  ../tracker/IO.cpp
+  ../tracker/CLM.cpp
+  ../tracker/FDet.cpp
+  ../tracker/Patch.cpp
+  ../tracker/ShapeModel.cpp
+  # ../tracker/PRA.cpp
+  # ../tracker/FacePredictor.cpp
+  ../tracker/ShapePredictor.cpp
+  ../tracker/ATM.cpp
+  ../tracker/Warp.cpp
+  ../tracker/FCheck.cpp
+  ../tracker/FaceTracker.cpp
+  ../tracker/myFaceTracker.cpp
+  ../tracker/RegistrationCheck.cpp
+  ../avatar/Avatar.cpp
+  ../avatar/myAvatar.cpp
 )
 
-SET(MOC_HEADERS
-  "controllers.hpp"
-  "gui/avatar-selection.hpp"
-  "gui/main-window.hpp"
-  "gui/avatar.hpp"
-#  "gui/mesh-drawer.hpp"
-  "gui/graphics-scrollbar.hpp"
-  "gui/windowed-gui-controller.hpp"
-  "gui/item-controllers.hpp"
-  "gui/worker-thread.hpp")
-#  "gui/item-positions-calculator.hpp")
+# SET(MOC_HEADERS
+#   "controllers.hpp"
+#   "gui/avatar-selection.hpp"
+#   "gui/main-window.hpp"
+#   "gui/avatar.hpp"
+# #  "gui/mesh-drawer.hpp"
+#   "gui/graphics-scrollbar.hpp"
+#   "gui/windowed-gui-controller.hpp"
+#   "gui/item-controllers.hpp"
+#   "gui/worker-thread.hpp")
+# #  "gui/item-positions-calculator.hpp")
 
-QT4_WRAP_CPP(MOC_SRCS ${MOC_HEADERS})
+# QT4_WRAP_CPP(MOC_SRCS ${MOC_HEADERS})
 
 INCLUDE_DIRECTORIES(".")
 set_source_files_properties(osx-configuration.mm PROPERTIES COMPILE_FLAGS -ObjC++)
@@ -45,7 +99,10 @@ add_executable(demo-application
   ${guiFILES}
   ${MOC_SRCS}
   ${EXTRA_SRC})
-target_link_libraries(demo-application ${LIBS} ${QT_LIBRARIES} clmTracker avatarAnim utilities ${EXTRA_LIBS})
+target_link_libraries(demo-application ${LIBS} 
+  # ${QT_LIBRARIES} 
+  Qt5::Widgets
+  clmTracker avatarAnim utilities ${EXTRA_LIBS})
 
 # Apple Specific Targets
 
@@ -65,7 +122,10 @@ ADD_EXECUTABLE(${BundleName} MACOSX_BUNDLE
   ${MOC_SRCS}
   ${EXTRA_SRC}
   )
-TARGET_LINK_LIBRARIES(${BundleName} ${LIBS} ${QT_LIBRARIES} clmTracker avatarAnim ${EXTRA_LIBS})
+TARGET_LINK_LIBRARIES(${BundleName} ${LIBS} 
+  # ${QT_LIBRARIES} 
+  Qt5::Widgets
+  clmTracker avatarAnim ${EXTRA_LIBS})
 
 
 # IF(APPLE)

--- a/src/qt-gui/CMakeLists.txt
+++ b/src/qt-gui/CMakeLists.txt
@@ -4,10 +4,8 @@
 # INCLUDE( ${QT_USE_FILE} )
 
 # qt
-if(APPLE)
-    set(QTDIR /Users/lusheng/Qt/5.11.1/clang_64)
-    set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QTDIR})
-endif(APPLE)
+set(QTDIR "" CACHE PATH "Qt5 directory")
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QTDIR})
 find_package(Qt5Widgets CONFIG REQUIRED)
 include_directories(${Qt5Widgets_INCLUDE_DIRS})
 
@@ -16,15 +14,10 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 
 # opencv
-if(WIN32)
-    set(opencv_DIR E:/toolkits/opencv-3.2.0-contrib-cpu)
-endif(WIN32)
-if(APPLE)
-    set(opencv_DIR ~/toolkits/opencv-3.4.1-mac/share/OpenCV)
-endif(APPLE)
-find_package(opencv REQUIRED)
+set(OpenCV_DIR "" CACHE PATH "OpenCV root directory")
+find_package(OpenCV REQUIRED)
 include_directories(${OpenCV_INCLUDE_DIRS})
-message("OpenCV_INCLUDE_DIRS = ${OpenCV_INCLUDE_DIRS}")
+# message("OpenCV_INCLUDE_DIRS = ${OpenCV_INCLUDE_DIRS}")
 
 #set(CMAKE_VERBOSE_MAKEFILE true)
 

--- a/src/qt-gui/controllers.hpp
+++ b/src/qt-gui/controllers.hpp
@@ -21,7 +21,7 @@
 #define _CI2CV_GUI_GUI_CONTROLLER_HPP_
 
 #include <QtCore/QObject>
-#include <QtGui/QImage>
+#include <QImage>
 #include <opencv2/core/core.hpp>
 
 namespace CI2CVGui

--- a/src/qt-gui/gui/avatar-selection.cpp
+++ b/src/qt-gui/gui/avatar-selection.cpp
@@ -20,8 +20,8 @@
 #include "gui/avatar-selection.hpp"
 #include "controllers.hpp"
 
-#include <QtCore/QDebug>
-#include <QtGui/QGraphicsSceneMouseEvent>
+#include <QDebug>
+#include <QGraphicsSceneMouseEvent>
 
 using namespace CI2CVGui;
 

--- a/src/qt-gui/gui/avatar-selection.hpp
+++ b/src/qt-gui/gui/avatar-selection.hpp
@@ -22,7 +22,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QRectF>
-#include <QtGui/QGraphicsItemGroup>
+#include <QGraphicsItemGroup>
 #include <QtCore/QScopedArrayPointer>
 
 #include "gui/graphics-scrollbar.hpp"

--- a/src/qt-gui/gui/avatar.cpp
+++ b/src/qt-gui/gui/avatar.cpp
@@ -20,7 +20,7 @@
 #include "gui/avatar.hpp"
 
 #include <stdexcept>
-#include <QtCore/QDebug>
+#include <QDebug>
 #include "gui/worker-thread.hpp"
 #include "configuration.hpp"
 

--- a/src/qt-gui/gui/graphics-scrollbar.cpp
+++ b/src/qt-gui/gui/graphics-scrollbar.cpp
@@ -19,8 +19,8 @@
 
 #include "gui/graphics-scrollbar.hpp"
 #include <QtGui/QPainterPath>
-#include <QtCore/QDebug>
-#include <QtGui/QGraphicsSceneMouseEvent>
+#include <QDebug>
+#include <QGraphicsSceneMouseEvent>
 
 using namespace CI2CVGui;
 

--- a/src/qt-gui/gui/graphics-scrollbar.hpp
+++ b/src/qt-gui/gui/graphics-scrollbar.hpp
@@ -22,7 +22,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QRectF>
-#include <QtGui/QGraphicsItemGroup>
+#include <QGraphicsItemGroup>
 #include <QtGui/QBrush>
 #include <QtGui/QPen>
 

--- a/src/qt-gui/gui/item-controllers.cpp
+++ b/src/qt-gui/gui/item-controllers.cpp
@@ -19,7 +19,7 @@
 
 #include "gui/item-controllers.hpp"
 #include <QtCore/QPropertyAnimation>
-#include <QtCore/QDebug>
+#include <QDebug>
 #include "gui/avatar-selection.hpp"
 #include "gui/mesh-drawer.hpp"
 #include "controllers.hpp"

--- a/src/qt-gui/gui/item-controllers.hpp
+++ b/src/qt-gui/gui/item-controllers.hpp
@@ -21,8 +21,8 @@
 #define _CI2CV_GUI_GUI_ITEM_POSITIONERS_HPP_
 
 #include <QtCore/QObject>
-#include <QtGui/QGraphicsRectItem>
-#include <QtGui/QGraphicsPixmapItem>
+#include <QGraphicsRectItem>
+#include <QGraphicsPixmapItem>
 
 #include <opencv2/core/core.hpp>
 

--- a/src/qt-gui/gui/item-positions-calculator.cpp
+++ b/src/qt-gui/gui/item-positions-calculator.cpp
@@ -20,7 +20,7 @@
 #include "gui/item-positions-calculator.hpp"
 #include "gui/windowed-gui-controller.hpp"
 
-#include <QtCore/QDebug>
+#include <QDebug>
 
 using namespace CI2CVGui;
 

--- a/src/qt-gui/gui/main-window.cpp
+++ b/src/qt-gui/gui/main-window.cpp
@@ -24,12 +24,12 @@
 #include "gui/mesh-drawer.hpp"
 #include "configuration.hpp"
 
-#include <QtGui/QStyle>
+#include <QStyle>
 #include <QtGui/QFont>
-#include <QtGui/QVBoxLayout>
-#include <QtGui/QHBoxLayout>
-#include <QtGui/QApplication>
-#include <QtCore/QDebug>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QApplication>
+#include <QDebug>
 
 using namespace CI2CVGui;
 

--- a/src/qt-gui/gui/main-window.hpp
+++ b/src/qt-gui/gui/main-window.hpp
@@ -20,13 +20,13 @@
 #ifndef _CI2CV_GUI_GUI_MAIN_WINDOW_HPP_
 #define _CI2CV_GUI_GUI_MAIN_WINDOW_HPP_
 
-#include <QtGui/QMainWindow>
-#include <QtGui/QGraphicsView>
-#include <QtGui/QGraphicsScene>
-#include <QtGui/QPushButton>
-#include <QtGui/QCheckBox>
-#include <QtGui/QLabel>
-#include <QtGui/QProgressBar>
+#include <QMainWindow>
+#include <QGraphicsView>
+#include <QGraphicsScene>
+#include <QPushButton>
+#include <QCheckBox>
+#include <QLabel>
+#include <QProgressBar>
 
 #include "gui/item-controllers.hpp"
 

--- a/src/qt-gui/gui/mesh-drawer.cpp
+++ b/src/qt-gui/gui/mesh-drawer.cpp
@@ -20,8 +20,8 @@
 #include "gui/mesh-drawer.hpp"
 #include "controllers.hpp"
 
-#include <QtGui/QGraphicsLineItem>
-#include <QtGui/QGraphicsEllipseItem>
+#include <QGraphicsLineItem>
+#include <QGraphicsEllipseItem>
 
 using namespace CI2CVGui;
 

--- a/src/qt-gui/gui/mesh-drawer.hpp
+++ b/src/qt-gui/gui/mesh-drawer.hpp
@@ -20,7 +20,7 @@
 #ifndef _CI2CV_GUI_GUI_MESH_DRAWER_HPP_
 #define _CI2CV_GUI_GUI_MESH_DRAWER_HPP_
 
-#include <QtGui/QGraphicsItemGroup>
+#include <QGraphicsItemGroup>
 #include <QtGui/QColor>
 #include <QtGui/QBrush>
 #include <QtGui/QPen>

--- a/src/qt-gui/gui/windowed-gui-controller.cpp
+++ b/src/qt-gui/gui/windowed-gui-controller.cpp
@@ -19,7 +19,7 @@
 
 #include "gui/windowed-gui-controller.hpp"
 
-#include <QtCore/QDebug>
+#include <QDebug>
 #include <stdexcept>
 #include "gui/worker-thread.hpp"
 #include "configuration.hpp"

--- a/src/qt-gui/gui/windowed-gui-controller.hpp
+++ b/src/qt-gui/gui/windowed-gui-controller.hpp
@@ -20,11 +20,11 @@
 #ifndef _CI2CV_GUI_GUI_WINDOWED_GUI_CONTROLLER_HPP_
 #define _CI2CV_GUI_GUI_WINDOWED_GUI_CONTROLLER_HPP_
 
-#include <QtGui/QWidget>
-#include <QtGui/QAbstractButton>
-#include <QtCore/QTimer>
-#include <QtGui/QLabel>
-#include <QtGui/QProgressBar>
+#include <QWidget>
+#include <QAbstractButton>
+#include <QTimer>
+#include <QLabel>
+#include <QProgressBar>
 
 #include "controllers.hpp"
 #include "gui/item-controllers.hpp"

--- a/src/qt-gui/gui/worker-thread.cpp
+++ b/src/qt-gui/gui/worker-thread.cpp
@@ -20,7 +20,7 @@
 #include "gui/worker-thread.hpp"
 
 #include <opencv/highgui.h>
-#include <QtCore/QDebug>
+#include <QDebug>
 #include <stdexcept>
 #include <numeric>
 

--- a/src/qt-gui/gui/worker-thread.hpp
+++ b/src/qt-gui/gui/worker-thread.hpp
@@ -25,9 +25,9 @@
 
 #include <opencv/cv.h>
 #include <opencv/highgui.h>
-#include <QtCore/QThread>
-#include <QtGui/QImage>
-#include <QtCore/QTimer>
+#include <QThread>
+#include <QImage>
+#include <QTimer>
 
 namespace CI2CVGui {
 	class WorkerThreadCameraController : public CameraController

--- a/src/qt-gui/main.cpp
+++ b/src/qt-gui/main.cpp
@@ -18,9 +18,9 @@
 // Copyright CSIRO 2013
 
 #include <QtCore/QObject>
-#include <QtGui/QApplication>
+#include <QApplication>
 #include <QtCore/QStateMachine>
-#include <QtCore/QDebug>
+#include <QDebug>
 
 #include <stdexcept>
 #include <iostream>

--- a/src/qt-gui/osx-configuration.mm
+++ b/src/qt-gui/osx-configuration.mm
@@ -22,7 +22,7 @@
 #include <Foundation/NSPathUtilities.h>
 #include <Foundation/NSAutoreleasePool.h>
 #include <Foundation/NSDictionary.h>
-#include <QtCore/QDebug>
+#include <QDebug>
 
 #include "osx-configuration.hpp"
 

--- a/src/tracker/ATM.hpp
+++ b/src/tracker/ATM.hpp
@@ -21,6 +21,7 @@
 #define _TRACKER_ATM_h_
 #include <tracker/ShapeModel.hpp>
 #include <tracker/Warp.hpp>
+#include <opencv2/opencv.hpp>
 #include <vector>
 namespace FACETRACKER
 {

--- a/src/tracker/CLM.hpp
+++ b/src/tracker/CLM.hpp
@@ -22,6 +22,7 @@
 #include <tracker/ShapeModel.hpp>
 #include <tracker/Patch.hpp>
 #include <tracker/Detector.hpp>
+#include <opencv2/opencv.hpp>
 #include <vector>
 namespace FACETRACKER
 {

--- a/src/tracker/Detector.cpp
+++ b/src/tracker/Detector.cpp
@@ -17,7 +17,7 @@
 
 // Copyright CSIRO 2013
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 
 #include "Detector.hpp"
 #include "IO.hpp"

--- a/src/tracker/Detector.hpp
+++ b/src/tracker/Detector.hpp
@@ -20,7 +20,7 @@
 #ifndef DETECTOR_CLASS_HPP_
 #define DETECTOR_CLASS_HPP_
 
-#include <opencv2/core/core.hpp>
+#include <opencv2/opencv.hpp>
 #include <tracker/Patch.hpp>
 
 #define DETECTOR_BAD_RESPONSE -.001

--- a/src/tracker/FCheck.hpp
+++ b/src/tracker/FCheck.hpp
@@ -20,6 +20,7 @@
 #ifndef _TRACKER_FCheck_h_
 #define _TRACKER_FCheck_h_
 #include <tracker/Warp.hpp>
+#include <opencv2/opencv.hpp>
 #include <vector>
 namespace FACETRACKER
 {

--- a/src/tracker/FDet.cpp
+++ b/src/tracker/FDet.cpp
@@ -18,6 +18,7 @@
 // Copyright CSIRO 2013
 
 #include <tracker/FDet.hpp>
+#include <opencv2/opencv.hpp>
 using namespace FACETRACKER;
 using namespace std;
 #define TSCALE 0.3

--- a/src/tracker/FDet.hpp
+++ b/src/tracker/FDet.hpp
@@ -20,6 +20,7 @@
 #ifndef _TRACKER_FDet_h_
 #define _TRACKER_FDet_h_
 #include <tracker/IO.hpp>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {
   //===========================================================================

--- a/src/tracker/FaceTracker.hpp
+++ b/src/tracker/FaceTracker.hpp
@@ -20,6 +20,7 @@
 #ifndef _TRACKER_FaceTracker_h_
 #define _TRACKER_FaceTracker_h_
 #include <tracker/IO.hpp>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {
   //============================================================================

--- a/src/tracker/IO.cpp
+++ b/src/tracker/IO.cpp
@@ -237,7 +237,7 @@ void IOBinary::ReadMat(std::ifstream &s, cv::Mat &M)
 	s.read((char*)&c, sizeof(int));
 	s.read((char*)&t, sizeof(int));
 	M = cv::Mat(r,c,t);
-	s.read(reinterpret_cast<char*>(M.datastart), M.total()*M.elemSize());
+	s.read((char*)(M.data), M.total()*M.elemSize());
 	
 	if(!s.good()){
 	  std::cout << "Error reading matrix" << std::endl;
@@ -254,7 +254,7 @@ void IOBinary::WriteMat(std::ofstream &s, cv::Mat &M)
 	s.write(reinterpret_cast<char*>(&M.cols), sizeof(int));
 	s.write(reinterpret_cast<char*>(&t), sizeof(int));
 	//	s << M.rows << " " << M.cols << " " << M.type();
-	s.write(reinterpret_cast<char*>(M.datastart), M.total()*M.elemSize());
+	s.write((char*)(M.data), M.total()*M.elemSize());
 
 	//	std::cout << "Mat written: "<< M.rows << "x"<< M.cols << ", type " << M.type() << std::endl; 
 

--- a/src/tracker/IO.hpp
+++ b/src/tracker/IO.hpp
@@ -22,6 +22,7 @@
 #include <opencv/cv.h>
 #include <fstream>
 #include <vector>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {
   //===========================================================================

--- a/src/tracker/Patch.hpp
+++ b/src/tracker/Patch.hpp
@@ -20,6 +20,7 @@
 #ifndef _TRACKER_Patch_h_
 #define _TRACKER_Patch_h_
 #include <tracker/IO.hpp>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {
   //===========================================================================

--- a/src/tracker/RegistrationCheck.hpp
+++ b/src/tracker/RegistrationCheck.hpp
@@ -20,6 +20,7 @@
 #ifndef _TRACKER_RegistrationCheck_h_
 #define _TRACKER_RegistrationCheck_h_
 #include <tracker/Warp.hpp>
+#include <opencv2/opencv.hpp>
 #include <vector>
 namespace FACETRACKER
 {

--- a/src/tracker/ShapeModel.hpp
+++ b/src/tracker/ShapeModel.hpp
@@ -20,6 +20,7 @@
 #ifndef _TRACKER_ShapeModel_h_
 #define _TRACKER_ShapeModel_h_
 #include <tracker/IO.hpp>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {
   //===========================================================================

--- a/src/tracker/ShapePredictor.hpp
+++ b/src/tracker/ShapePredictor.hpp
@@ -21,6 +21,7 @@
 #define _TRACKER_ShapePredictor_h_
 #include <tracker/ShapeModel.hpp>
 #include <tracker/Warp.hpp>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {  
   //===========================================================================

--- a/src/tracker/Warp.hpp
+++ b/src/tracker/Warp.hpp
@@ -20,6 +20,7 @@
 #ifndef _TRACKER_Warp_h_
 #define _TRACKER_Warp_h_
 #include <tracker/IO.hpp>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {
   //===========================================================================

--- a/src/tracker/myFaceTracker.hpp
+++ b/src/tracker/myFaceTracker.hpp
@@ -26,6 +26,7 @@
 #include <tracker/RegistrationCheck.hpp>
 #include <tracker/FaceTracker.hpp>
 #include <tracker/ShapePredictor.hpp>
+#include <opencv2/opencv.hpp>
 namespace FACETRACKER
 {
   //============================================================================


### PR DESCRIPTION
- update from Qt4 to Qt5
- cmake support for user defined path of Qt5: `QTDIR`
- change OpenCV includes to <opencv2/opencv.hpp>
- compile and execute tested on Mac OSX